### PR TITLE
Fix memory allocation error message

### DIFF
--- a/mem_limit/mem_limit.cc
+++ b/mem_limit/mem_limit.cc
@@ -348,9 +348,12 @@ long convert_time(const char *time_spec) {
 }
 
 char* allocate_memory(size_t size) {
-    char* buffer {NULL};
-    if ((buffer = (char*) malloc(size*sizeof(char))) == NULL)
-        throw std::runtime_error("can allocate memory");
+    char* buffer {nullptr};
+    if ((buffer = static_cast<char*>(malloc(size * sizeof(char)))) == nullptr) {
+        std::stringstream ss;
+        ss << "can't allocate memory (" << size << " bytes)";
+        throw std::runtime_error(ss.str());
+    }
     return buffer;
 }
 


### PR DESCRIPTION
## Summary
- refine error message when memory allocation fails in `mem_limit`
- include the requested size in the runtime error message

## Testing
- `make -C mem_limit mem_limit_no_mpi`
- `make -C alloc`
- `./mem_limit/mem_limit_no_mpi -h`
- `./mem_limit/mem_limit_no_mpi -m 1gb -i 1gb -s 0 -l 1s`
- `./mem_limit/mem_limit_no_mpi -m 10000000000000 -i 10000000000000 -s 0 -l 1s`

------
https://chatgpt.com/codex/tasks/task_e_6852d552170c8329a8393c52a07b083d

## Summary by Sourcery

Enhancements:
- Refine allocation failure message to indicate the number of bytes requested