### PR TITLE
Fix help text typo

### DIFF
--- a/mem_limit/mem_limit.cc
+++ b/mem_limit/mem_limit.cc
@@ -453,7 +453,7 @@ void print_help() {
     msg << "\t-m <size>: maximum memory size" << std::endl;
     msg << "\t-i <size>: memory increment per step" << std::endl;
     msg << "\t-s <time>: time to sleep between steps" << std::endl;
-    msg << "\t-t <n>: number of threads per processs" << std::endl;
+    msg << "\t-t <n>: number of threads per process" << std::endl;
     msg << "\t-l <time>: time to stay alive after last step" << std::endl;
     msg << "\t-v: give verbose output" << std::endl;
     msg << "\t-h: show this help message" << std::endl;
@@ -462,4 +462,5 @@ void print_help() {
     msg << "<time> takes units m, s, ms, us, default is microseconds"
         << std::endl;
     std::cerr << msg.str();
+    std::cerr << std::endl;
 }


### PR DESCRIPTION
## Summary
- fix `processs` typo in `mem_limit` help text
- ensure help text ends with a newline for cleaner output

## Testing
- `make -C mem_limit` *(fails: mpic++ not found)*
- `make -C alloc`

------
https://chatgpt.com/codex/tasks/task_e_6852d586b94c83299ed1154d48968bff