### PR TITLE
Improve parsing robustness in check_pinning.py

### DIFF
--- a/mem_limit/check_pinning.py
+++ b/mem_limit/check_pinning.py
@@ -34,6 +34,9 @@ if __name__ == '__main__':
             else:
                 try:
                     data = line.strip().split()
+                    if len(data) < 4:
+                        raise ValueError('expected at least 4 fields, got {0}'
+                                         .format(len(data)))
                     thread = data[1]
                     core = data[3]
                     if thread in thread_placement:
@@ -48,9 +51,9 @@ if __name__ == '__main__':
                     else:
                         thread_placement[thread] = core
                 except Exception as e:
-                    msg = "### error: {0} on line\n\t'{1}'"
-                    sys.stderr.write(msg.format(str(e), line))
-                    sys.exit(2)
+                    msg = "### warning: {0} on line\n\t'{1}'\n"
+                    sys.stderr.write(msg.format(str(e), line.strip()))
+                    continue
         if moving_threads:
             msg = 'Summary: {0:d}/{1:d} threads moved, {2:d} total moves'
             print(msg.format(len(moving_threads), len(thread_placement),

--- a/tests/test_check_pinning.py
+++ b/tests/test_check_pinning.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import subprocess
+import tempfile
+import unittest
+
+SCRIPT = os.path.join(os.path.dirname(__file__), '..', 'mem_limit', 'check_pinning.py')
+
+class CheckPinningTests(unittest.TestCase):
+
+    def run_script(self, content, *args):
+        with tempfile.NamedTemporaryFile('w+', delete=False) as f:
+            f.write(content)
+            fname = f.name
+        try:
+            result = subprocess.run([
+                sys.executable, SCRIPT, *args, fname
+            ], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        finally:
+            os.unlink(fname)
+        return result
+
+    def test_normal_input(self):
+        content = """====\nfoo 0#0 bar 0\nfoo 0#0 bar 2\nfoo 1#0 bar 0\n====\n"""
+        res = self.run_script(content)
+        self.assertEqual(res.returncode, 0)
+        self.assertIn('Summary: 1/2 threads moved, 1 total moves', res.stdout)
+        self.assertEqual(res.stderr, '')
+
+    def test_malformed_input(self):
+        content = """====\nfoo 0#0 bar 0\nbad line\nfoo 0#0 bar 1\n====\n"""
+        res = self.run_script(content)
+        self.assertEqual(res.returncode, 0)
+        self.assertIn('warning', res.stderr.lower())
+        self.assertIn('Summary: 1/1 threads moved, 1 total moves', res.stdout)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- validate token count when parsing lines in `check_pinning.py`
- warn on malformed lines instead of aborting
- add unit tests for normal and malformed log input

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68554c0a8ee48329a247ed746e8dd52e

## Summary by Sourcery

Improve the robustness of the check_pinning script by validating line formats, emitting warnings for malformed entries rather than exiting, and adding tests to cover both valid and invalid inputs

Bug Fixes:
- Handle malformed log lines with warnings instead of aborting the script

Enhancements:
- Validate token count when parsing lines in check_pinning.py to guard against incomplete entries

Tests:
- Add unit tests for normal and malformed log inputs to verify warnings and summary output