### PR TITLE
Ignore compiled binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,11 @@
 
 # vim backup files
 *~
+
+# Compiled binaries
+/mem_limit/mem_limit
+/mem_limit/mem_limit_no_mpi
+/alloc/alloc
+
+# Python cache directories
+__pycache__/


### PR DESCRIPTION
## Summary
- ignore compiled `mem_limit` and `alloc` binaries
- ignore `__pycache__` folders

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685555fca6bc83299ec73a5c8ddea919

## Summary by Sourcery

Update .gitignore to exclude compiled binaries and Python cache directories

Chores:
- Add mem_limit and alloc binaries to .gitignore
- Add __pycache__ directories to .gitignore