### PR TITLE
Fix help output side effects

### DIFF
--- a/mem_limit/mem_limit.cc
+++ b/mem_limit/mem_limit.cc
@@ -130,10 +130,12 @@ int main(int argc, char *argv[]) {
             print_help();
             is_done = 1;
         }
-        std::stringstream msg;
-        msg << "running with " << size << " processes"
-            << std::endl;
-        std::cout << msg.str();
+        if (!is_done) {
+            std::stringstream msg;
+            msg << "running with " << size << " processes"
+                << std::endl;
+            std::cout << msg.str();
+        }
     }
 #ifndef NO_MPI
     MPI_Bcast(&is_done, 1, MPI_INT, root, MPI_COMM_WORLD);


### PR DESCRIPTION
## Summary
- avoid printing number of processes when exiting early for help or errors

## Testing
- `make -C mem_limit mem_limit_no_mpi`

------
https://chatgpt.com/codex/tasks/task_e_685555f991348329b2989b0e393d4c2e

## Summary by Sourcery

Bug Fixes:
- Prevent 'running with X processes' message from printing when exiting early for help or errors.